### PR TITLE
feat(documents): implement static UI for document management module

### DIFF
--- a/apps/client/src/features/documents/components/AIInsights.tsx
+++ b/apps/client/src/features/documents/components/AIInsights.tsx
@@ -1,0 +1,54 @@
+import { FileText, Clock, AlertCircle, Sparkles } from 'lucide-react';
+import { Button } from '@/shared/components/ui/button';
+
+export function AIInsights() {
+    return (
+        <div className="bg-secondary/50 rounded-3xl p-8 border border-border/50 shadow-sm relative overflow-hidden group">
+            <div className="absolute top-0 right-0 p-8 opacity-10 group-hover:opacity-20 transition-opacity">
+                <Sparkles className="w-32 h-32" />
+            </div>
+
+            <div className="flex items-center gap-3 mb-6 relative z-10">
+                <div className="p-2 bg-blue-600/20 rounded-lg text-blue-400">
+                    <Sparkles className="w-5 h-5" />
+                </div>
+                <h3 className="text-xl font-bold bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">AI Insights</h3>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-6 relative z-10">
+                {/* Insight Card 1 */}
+                <div className="bg-background rounded-2xl p-5 border border-border/50 shadow-sm hover:shadow-md transition-all cursor-pointer group/card flex flex-col items-start gap-4">
+                    <div className="p-3 bg-blue-50 dark:bg-blue-500/10 rounded-xl text-blue-600">
+                        <FileText className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="text-sm font-medium mb-1 line-clamp-2 text-foreground">You have 3 documents related to 'Roadmap 2024'.</p>
+                        <Button variant="link" className="p-0 h-auto text-xs text-blue-500 font-bold group-hover/card:underline">Consolidate them?</Button>
+                    </div>
+                </div>
+
+                {/* Insight Card 2 */}
+                <div className="bg-background rounded-2xl p-5 border border-border/50 shadow-sm hover:shadow-md transition-all cursor-pointer group/card flex flex-col items-start gap-4">
+                    <div className="p-3 bg-orange-50 dark:bg-orange-500/10 rounded-xl text-orange-600">
+                        <Clock className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="text-sm font-medium mb-1 line-clamp-2 text-foreground">Project Ideas has not been updated in 9 days.</p>
+                        <Button variant="link" className="p-0 h-auto text-orange-500 font-bold group-hover/card:underline">Schedule review?</Button>
+                    </div>
+                </div>
+
+                {/* Insight Card 3 */}
+                <div className="bg-background rounded-2xl p-5 border border-border/50 shadow-sm hover:shadow-md transition-all cursor-pointer group/card flex flex-col items-start gap-4">
+                    <div className="p-3 bg-red-50 dark:bg-red-500/10 rounded-xl text-red-600">
+                        <AlertCircle className="w-5 h-5" />
+                    </div>
+                    <div>
+                        <p className="text-sm font-medium mb-1 line-clamp-2 text-foreground">Marketing Assets does not link to any roadmap.</p>
+                        <Button variant="link" className="p-0 h-auto text-red-500 font-bold group-hover/card:underline">Fix disconnect</Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/features/documents/components/CreateDocumentDialog.tsx
+++ b/apps/client/src/features/documents/components/CreateDocumentDialog.tsx
@@ -1,0 +1,132 @@
+import { FileText, FileUp, Link2, ExternalLink } from 'lucide-react';
+import { Button } from '@/shared/components/ui/button';
+import { Input } from '@/shared/components/ui/input';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/shared/components/ui/dialog';
+import type { DocumentSource } from '../types';
+
+interface CreateDocumentDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    selectedDocSource: DocumentSource;
+    onSourceSelect: (source: DocumentSource) => void;
+    externalLink: string;
+    onExternalLinkChange: (link: string) => void;
+    onExternalLinkSubmit: () => void;
+    onEditorOpen: () => void;
+}
+
+export function CreateDocumentDialog({
+    open,
+    onOpenChange,
+    selectedDocSource,
+    onSourceSelect,
+    externalLink,
+    onExternalLinkChange,
+    onExternalLinkSubmit,
+    onEditorOpen,
+}: CreateDocumentDialogProps) {
+    const handleSourceSelect = (source: DocumentSource) => {
+        onSourceSelect(source);
+        if (source === 'blank') {
+            onOpenChange(false);
+            onEditorOpen();
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Create New Document</DialogTitle>
+                </DialogHeader>
+
+                {!selectedDocSource ? (
+                    <div className="grid grid-cols-1 gap-3 pt-4">
+                        <button
+                            onClick={() => handleSourceSelect('blank')}
+                            className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:bg-secondary/50 hover:border-primary/30 transition-all text-left group"
+                        >
+                            <div className="p-3 rounded-xl bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
+                                <FileText className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h4 className="font-semibold text-foreground">Blank Document</h4>
+                                <p className="text-sm text-muted-foreground">Start from scratch with a new document</p>
+                            </div>
+                        </button>
+
+                        <button
+                            onClick={() => handleSourceSelect('notion')}
+                            className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:bg-secondary/50 hover:border-primary/30 transition-all text-left group"
+                        >
+                            <div className="p-3 rounded-xl bg-purple-500/10 text-purple-500 group-hover:bg-purple-500 group-hover:text-white transition-colors">
+                                <FileUp className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h4 className="font-semibold text-foreground">Sync from Notion</h4>
+                                <p className="text-sm text-muted-foreground">Import and sync a Notion document</p>
+                            </div>
+                        </button>
+
+                        <button
+                            onClick={() => handleSourceSelect('link')}
+                            className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:bg-secondary/50 hover:border-primary/30 transition-all text-left group"
+                        >
+                            <div className="p-3 rounded-xl bg-blue-500/10 text-blue-500 group-hover:bg-blue-500 group-hover:text-white transition-colors">
+                                <Link2 className="w-5 h-5" />
+                            </div>
+                            <div>
+                                <h4 className="font-semibold text-foreground">Add External Link</h4>
+                                <p className="text-sm text-muted-foreground">Link to Google Docs, Dropbox, or any URL</p>
+                            </div>
+                        </button>
+                    </div>
+                ) : selectedDocSource === 'notion' ? (
+                    <div className="space-y-4 pt-4">
+                        <div className="p-4 rounded-xl bg-purple-500/10 border border-purple-500/20">
+                            <div className="flex items-center gap-3 mb-3">
+                                <FileUp className="w-5 h-5 text-purple-500" />
+                                <h4 className="font-semibold text-foreground">Connect Notion</h4>
+                            </div>
+                            <p className="text-sm text-muted-foreground mb-4">
+                                Connect your Notion workspace to sync documents automatically.
+                            </p>
+                            <Button className="w-full bg-purple-600 hover:bg-purple-700">
+                                Connect Notion Account
+                            </Button>
+                        </div>
+                        <Button variant="ghost" onClick={() => onSourceSelect(null)} className="w-full">
+                            Back to options
+                        </Button>
+                    </div>
+                ) : selectedDocSource === 'link' ? (
+                    <div className="space-y-4 pt-4">
+                        <div className="space-y-2">
+                            <label className="text-sm font-medium text-foreground">Document URL</label>
+                            <div className="flex gap-2">
+                                <Input
+                                    placeholder="https://docs.google.com/..."
+                                    value={externalLink}
+                                    onChange={(e) => onExternalLinkChange(e.target.value)}
+                                    className="flex-1"
+                                />
+                            </div>
+                            <p className="text-xs text-muted-foreground">
+                                Paste a link to Google Docs, Dropbox, Figma, or any external document
+                            </p>
+                        </div>
+                        <div className="flex gap-2">
+                            <Button variant="ghost" onClick={() => onSourceSelect(null)} className="flex-1">
+                                Back
+                            </Button>
+                            <Button onClick={onExternalLinkSubmit} className="flex-1" disabled={!externalLink.trim()}>
+                                <ExternalLink className="w-4 h-4 mr-2" />
+                                Add Link
+                            </Button>
+                        </div>
+                    </div>
+                ) : null}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/client/src/features/documents/components/CreateFolderForm.tsx
+++ b/apps/client/src/features/documents/components/CreateFolderForm.tsx
@@ -1,0 +1,39 @@
+import { X } from 'lucide-react';
+import { Button } from '@/shared/components/ui/button';
+
+interface CreateFolderFormProps {
+    isVisible: boolean;
+    folderName: string;
+    onFolderNameChange: (name: string) => void;
+    onCancel: () => void;
+    onSubmit: () => void;
+}
+
+export function CreateFolderForm({
+    isVisible,
+    folderName,
+    onFolderNameChange,
+    onCancel,
+    onSubmit,
+}: CreateFolderFormProps) {
+    if (!isVisible) return null;
+
+    return (
+        <div className="bg-background rounded-2xl p-6 border border-border shadow-sm max-w-md animate-in fade-in slide-in-from-top-4">
+            <h3 className="font-bold mb-4">New Folder</h3>
+            <div className="flex gap-2">
+                <input
+                    autoFocus
+                    type="text"
+                    value={folderName}
+                    onChange={(e) => onFolderNameChange(e.target.value)}
+                    placeholder="Folder Name (e.g. Project X)..."
+                    className="flex-1 bg-secondary/30 rounded-xl px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    onKeyDown={(e) => e.key === 'Enter' && onSubmit()}
+                />
+                <Button size="sm" onClick={onSubmit}>Create</Button>
+                <Button size="icon" variant="ghost" onClick={onCancel}><X className="w-4 h-4" /></Button>
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/features/documents/components/DocumentTable.tsx
+++ b/apps/client/src/features/documents/components/DocumentTable.tsx
@@ -1,0 +1,50 @@
+import { MoreHorizontal } from 'lucide-react';
+import type { FileData } from '../types';
+
+interface DocumentTableProps {
+    files: FileData[];
+}
+
+export function DocumentTable({ files }: DocumentTableProps) {
+    return (
+        <div className="bg-card rounded-3xl p-8 border border-border/50 shadow-sm">
+            <div className="flex items-center justify-between mb-6">
+                <h3 className="text-xl font-bold">Recent Thoughts</h3>
+            </div>
+
+            <div className="space-y-1">
+                <div className="grid grid-cols-12 text-sm text-muted-foreground font-medium pb-4 px-4 border-b border-border/50">
+                    <div className="col-span-5">Name</div>
+                    <div className="col-span-2">Size</div>
+                    <div className="col-span-3">Last Modified</div>
+                    <div className="col-span-2">Members</div>
+                </div>
+                {files.map(file => (
+                    <div key={file.id} className="grid grid-cols-12 items-center py-4 px-4 hover:bg-secondary/20 rounded-xl transition-colors cursor-pointer group">
+                        <div className="col-span-5 flex items-center gap-3">
+                            <div className={`p-2 rounded bg-secondary/30 ${file.color}`}>
+                                <file.icon className="w-4 h-4" />
+                            </div>
+                            <span className="font-bold text-foreground">{file.name}</span>
+                        </div>
+                        <div className="col-span-2 text-sm text-muted-foreground">{file.size}</div>
+                        <div className="col-span-3 text-sm text-muted-foreground">{file.date}</div>
+                        <div className="col-span-2 flex items-center justify-between">
+                            <div className="flex -space-x-2">
+                                {[1, 2, 3].map(i => (
+                                    <img
+                                        key={i}
+                                        src={`https://api.dicebear.com/7.x/avataaars/svg?seed=User${file.id}${i}`}
+                                        className="w-6 h-6 rounded-full border-2 border-background"
+                                        alt={`User avatar ${i}`}
+                                    />
+                                ))}
+                            </div>
+                            <MoreHorizontal className="w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100" />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/features/documents/components/SpaceGrid.tsx
+++ b/apps/client/src/features/documents/components/SpaceGrid.tsx
@@ -1,0 +1,67 @@
+import { Folder as FolderIcon } from 'lucide-react';
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/components/ui/avatar';
+import { EmptyState } from '@/shared/components/ui/empty-state';
+import type { Folder } from '../types';
+
+interface SpaceGridProps {
+    folders: Folder[];
+    onCreateFolder: () => void;
+}
+
+export function SpaceGrid({ folders, onCreateFolder }: SpaceGridProps) {
+    return (
+        <div className="bg-card rounded-3xl p-8 border border-border/50 shadow-sm">
+            <div className="flex items-center justify-between mb-6">
+                <div className="flex items-center gap-2">
+                    <FolderIcon className="w-5 h-5 text-blue-600" />
+                    <span className="font-bold">Spaces</span>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-6">
+                {folders.map((folder, index) => (
+                    <div
+                        key={folder.id}
+                        className="p-4 bg-secondary/50 rounded-xl hover:bg-secondary transition-colors cursor-pointer animate-fade-in group hover:shadow-md border border-transparent hover:border-border/50"
+                        style={{ animationDelay: `${index * 50}ms` }}
+                    >
+                        <div className="flex items-start justify-between mb-3">
+                            <div className={`w-10 h-10 rounded-lg ${folder.color} flex items-center justify-center bg-opacity-20`}>
+                                <folder.icon className="w-5 h-5 text-white" />
+                            </div>
+                            {folder.members.length > 0 && (
+                                <div className="flex -space-x-1">
+                                    {folder.members.slice(0, 2).map((id) => (
+                                        <Avatar key={id} className="w-6 h-6 border-2 border-card">
+                                            <AvatarImage src={`https://api.dicebear.com/7.x/avataaars/svg?seed=User${id}`} />
+                                            <AvatarFallback className="text-[10px]">U</AvatarFallback>
+                                        </Avatar>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                        <h3 className="font-medium text-foreground">{folder.name}</h3>
+                        <p className="text-sm text-muted-foreground">{folder.files} thoughts</p>
+                    </div>
+                ))}
+
+                {/* Empty State if no folders */}
+                {folders.length === 0 && (
+                    <div className="col-span-full py-6">
+                        <EmptyState
+                            icon={FolderIcon}
+                            title="No spaces yet"
+                            description="Create a space to organize your documents and thoughts."
+                            action={{
+                                label: "Create Folder",
+                                onClick: onCreateFolder
+                            }}
+                            className="p-0 border-none"
+                            iconClassName="w-12 h-12 p-3 mb-4"
+                        />
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/client/src/features/documents/index.ts
+++ b/apps/client/src/features/documents/index.ts
@@ -1,0 +1,1 @@
+export { default as Documents } from './pages/index';

--- a/apps/client/src/features/documents/pages/index.tsx
+++ b/apps/client/src/features/documents/pages/index.tsx
@@ -1,0 +1,120 @@
+import { useState } from 'react';
+import {
+  Folder as FolderIcon,
+  Plus,
+  FileText,
+  Image as ImageIcon,
+} from 'lucide-react';
+import type { DocumentSource, Folder, FileData } from '../types';
+import { AIInsights } from '../components/AIInsights';
+import { SpaceGrid } from '../components/SpaceGrid';
+import { DocumentTable } from '../components/DocumentTable';
+import { CreateDocumentDialog } from '../components/CreateDocumentDialog';
+import { CreateFolderForm } from '../components/CreateFolderForm';
+
+// Initial mock folders
+const initialFolders: Folder[] = [
+  { id: 1, name: 'Project Ideas', files: 5, color: 'bg-blue-500', icon: FolderIcon, members: [1, 2, 3] },
+  { id: 2, name: 'Roadmap 2024', files: 12, color: 'bg-purple-500', icon: FolderIcon, members: [4, 5] },
+  { id: 3, name: 'Marketing Assets', files: 8, color: 'bg-orange-500', icon: FolderIcon, members: [1] },
+];
+
+const recentFiles: FileData[] = [
+  { id: 1, name: 'Proposal.docx', size: '2.9 MB', date: 'Feb 25, 2022', icon: FileText, color: 'text-blue-500' },
+  { id: 2, name: 'Background.jpg', size: '3.5 MB', date: 'Feb 24, 2022', icon: ImageIcon, color: 'text-blue-400' },
+  { id: 3, name: 'Apex website.fig', size: '23.5 MB', date: 'Feb 22, 2022', icon: FileText, color: 'text-purple-500' },
+  { id: 4, name: 'Illustration.ai', size: '7.2 MB', date: 'Feb 20, 2022', icon: ImageIcon, color: 'text-orange-500' },
+];
+
+function Documents() {
+  const [folders, setFolders] = useState<Folder[]>(initialFolders);
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState('');
+  const [showDocumentOptions, setShowDocumentOptions] = useState(false);
+  const [selectedDocSource, setSelectedDocSource] = useState<DocumentSource>(null);
+  const [externalLink, setExternalLink] = useState('');
+
+  const handleCreateFolder = () => {
+    if (!newFolderName.trim()) return;
+
+    const newFolder: Folder = {
+      id: Date.now(),
+      name: newFolderName,
+      files: 0,
+      color: 'bg-blue-500',
+      icon: FolderIcon,
+      members: [1]
+    };
+
+    setFolders([...folders, newFolder]);
+    setNewFolderName('');
+    setIsCreatingFolder(false);
+  };
+
+  const handleExternalLinkSubmit = () => {
+    if (externalLink.trim()) {
+      setExternalLink('');
+      setSelectedDocSource(null);
+      setShowDocumentOptions(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <div className="flex-1 p-8 grid grid-cols-12 gap-8">
+        <div className="col-span-12 flex flex-col gap-8">
+
+          {/* Header Controls */}
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold">Files</h2>
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => setIsCreatingFolder(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-secondary text-foreground rounded-xl hover:bg-secondary/80 transition-colors border border-border"
+              >
+                <Plus className="w-4 h-4" /> Create Folder
+              </button>
+              <button
+                onClick={() => setShowDocumentOptions(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-xl hover:bg-primary/90 transition-colors shadow-lg shadow-primary/20"
+              >
+                <FileText className="w-4 h-4" /> New Document
+              </button>
+            </div>
+          </div>
+
+          <CreateDocumentDialog
+            open={showDocumentOptions}
+            onOpenChange={setShowDocumentOptions}
+            selectedDocSource={selectedDocSource}
+            onSourceSelect={setSelectedDocSource}
+            externalLink={externalLink}
+            onExternalLinkChange={setExternalLink}
+            onExternalLinkSubmit={handleExternalLinkSubmit}
+            onEditorOpen={() => { }}
+          />
+
+          <CreateFolderForm
+            isVisible={isCreatingFolder}
+            folderName={newFolderName}
+            onFolderNameChange={setNewFolderName}
+            onCancel={() => setIsCreatingFolder(false)}
+            onSubmit={handleCreateFolder}
+          />
+
+          <AIInsights />
+
+          <SpaceGrid
+            folders={folders}
+            onCreateFolder={() => setIsCreatingFolder(true)}
+          />
+
+          <DocumentTable files={recentFiles} />
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Documents;

--- a/apps/client/src/features/documents/routes.ts
+++ b/apps/client/src/features/documents/routes.ts
@@ -1,0 +1,16 @@
+import { lazy } from 'react';
+import type { IRouteConfig } from '@/shared/types/route.type';
+import ROUTE_PATH from '@/shared/constant/route';
+
+const Documents = lazy(() => import('./').then((module) => ({ default: module.Documents })));
+
+const DOCUMENTS_ROUTE_CONFIG: IRouteConfig[] = [
+  {
+    path: ROUTE_PATH.DOCUMENTS,
+    element: Documents,
+    title: 'Documents',
+    description: 'Organize your Documents',
+  },
+];
+
+export default DOCUMENTS_ROUTE_CONFIG;

--- a/apps/client/src/features/documents/types.ts
+++ b/apps/client/src/features/documents/types.ts
@@ -1,0 +1,21 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type DocumentSource = 'blank' | 'notion' | 'link' | null;
+
+export interface Folder {
+    id: number;
+    name: string;
+    files: number;
+    color: string;
+    icon: LucideIcon;
+    members: number[];
+}
+
+export interface FileData {
+    id: number;
+    name: string;
+    size: string;
+    date: string;
+    icon: LucideIcon;
+    color: string;
+}

--- a/apps/client/src/routes/config.tsx
+++ b/apps/client/src/routes/config.tsx
@@ -10,6 +10,7 @@ import INBOX_ROUTE_CONFIG from '@/features/inbox/routes';
 import DASHBOARD_ROUTE_CONFIG from '@/features/dashboard/routes';
 import PROJECT_ROUTE_CONFIG from '@/features/projects/routes';
 import PROFILE_SETTINGS_CONFIG from '@/features/settings/routes';
+import DOCUMENTS_ROUTE_CONFIG from '@/features/documents/routes';
 
 /**
  * Not Found Page
@@ -26,6 +27,7 @@ export const appRoutes: IRouteConfig[] = [
   ...INBOX_ROUTE_CONFIG,
   ...PROJECT_ROUTE_CONFIG,
   ...PROFILE_SETTINGS_CONFIG,
+  ...DOCUMENTS_ROUTE_CONFIG,
   {
     path: '*',
     element: NotFound,


### PR DESCRIPTION
This pull request introduces a new "Documents" feature to the application, providing a user interface for document and folder management, as well as AI-powered insights. It includes the main Documents page, supporting components for folders and files, dialog and form components for creating new documents and folders, type definitions, and routing integration.

The most important changes are:

**Feature Implementation: Documents Page and Components**
- Added the main `Documents` page (`pages/index.tsx`) with state management for folders, files, and document creation dialogs, along with mock data for demonstration.
- Implemented supporting UI components:
  - `AIInsights` for displaying AI-driven suggestions and actions.
  - `SpaceGrid` for listing and managing folders/spaces, including an empty state.
  - `DocumentTable` for listing recent files with member avatars and actions.
  - `CreateDocumentDialog` for selecting the source of a new document (blank, Notion, or external link).
  - `CreateFolderForm` for creating new folders.

**Type Definitions**
- Added `types.ts` to define `DocumentSource`, `Folder`, and `FileData` interfaces, ensuring type safety and consistency across components.

**Routing Integration**
- Added `routes.ts` to register the Documents page in the application's route configuration and integrated it into the main routes config. [[1]](diffhunk://#diff-e1a6d6456d7ea7c9a75f7ff6aaf638d6de39f5ef1cc2cfe8253c0897eb51e8e9R1-R16) [[2]](diffhunk://#diff-21a322b1e6cce0f7e027b87b649e81f5e52bf9dcd20cbf5fb80fdeba27ef0e91R13)

**Module Export**
- Updated the `index.ts` file to export the `Documents` component for use in routing and lazy loading.